### PR TITLE
some bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ Then, in your babel configuration (usually in your `.babelrc` file), add `"macro
 - **1.0.1** fix npm package
 - **1.0.2** fix crash when missed some arguments
 - **1.0.3** fix behavior of same-name macros in different scopes.
-before this change same-name macros are re-declared.
-now macros in different scopes - are different macros.
-- **1.0.3** fix behavior of same-name macros in different scopes
+   before this change same-name macros are re-declared.
+   now macros in different scopes - are different macros.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Because macros are incredibly useful! Also because they make it easy to write ex
 - [ ] Refactor for readability
 - [ ] Allow macros to be imported and exported across files.
 - [ ] Add `DEFINE_TRANSFORM` which is similar to `DEFINE_MACRO` but allows direct AST manipulation, not merely replacement.
-- [x] Implement function inlining for macro arguments (in the map example above, the `_visitor` function body should be inlined, removing the function entirely).
+- [ ] Implement function inlining for macro arguments (in the map example above, the `_visitor` function body should be inlined, removing the function entirely).
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Because macros are incredibly useful! Also because they make it easy to write ex
 - [ ] Refactor for readability
 - [ ] Allow macros to be imported and exported across files.
 - [ ] Add `DEFINE_TRANSFORM` which is similar to `DEFINE_MACRO` but allows direct AST manipulation, not merely replacement.
-- [ ] Implement function inlining for macro arguments (in the map example above, the `_visitor` function body should be inlined, removing the function entirely).
+- [x] Implement function inlining for macro arguments (in the map example above, the `_visitor` function body should be inlined, removing the function entirely).
 
 # Installation
 
@@ -91,6 +91,15 @@ Then, in your babel configuration (usually in your `.babelrc` file), add `"macro
 }
 ```
 
+# ChangeLog
+- **0.0.1** base implementation
+- **1.0.0** update for babel@6 API
+- **1.0.1** fix npm package
+- **1.0.2** fix crash when missed some arguments
+- **1.0.3** fix behavior of same-name macros in different scopes.
+before this change same-name macros are re-declared.
+now macros in different scopes - are different macros.
+- **1.0.3** fix behavior of same-name macros in different scopes
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-macros",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Macros for JavaScript via a babel plugin.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixtures/define-after-using.js
+++ b/test/fixtures/define-after-using.js
@@ -1,0 +1,5 @@
+export default function demo () {
+  DEFINE_MACRO(BEFORE,()=>"before");
+  return [BEFORE(), AFTER()];
+  DEFINE_MACRO(AFTER,()=>"after");
+}

--- a/test/fixtures/different-levels.js
+++ b/test/fixtures/different-levels.js
@@ -1,0 +1,49 @@
+const parent0 = (function() {
+  return function() {
+    DEFINE_MACRO(FOO, function() {
+      return 'same level used';
+    });
+    return FOO();
+  };
+})();
+const parent1 = (function() {
+  DEFINE_MACRO(FOO, function() {
+    return 'parent level used';
+  });
+  return function() {
+    return FOO();
+  };
+})();
+const parent2 = (function() {
+  DEFINE_MACRO(FOO, function() {
+    return 'parent-parent level used';
+  });
+  return (function() {
+    return function() {
+      return FOO();
+    };
+  })();
+})();
+
+const child = (function() {
+  return function() {
+    function innerNotCalled() {
+      DEFINE_MACRO(FOO, function() {
+        return 'child level used';
+      });
+    }
+    try {
+      return FOO();
+    } catch(e) {
+      if(e.message === 'FOO is not defined') {
+        return 'child level cannot used';
+      } else {
+        throw e;
+      }
+    }
+  };
+})();
+
+export default function demo () {
+  return [parent0(), parent1(), parent2(), child()];
+}

--- a/test/fixtures/functions.js
+++ b/test/fixtures/functions.js
@@ -7,5 +7,5 @@ DEFINE_MACRO(NAMED, function NAMED() {
 });
 
 export default function demo() {
-  return [ARROW(), ANONYMOUS(), NAMED()].join('.');
+  return [ARROW(), ANONYMOUS(), NAMED()];
 }

--- a/test/fixtures/hoisting.js
+++ b/test/fixtures/hoisting.js
@@ -14,5 +14,5 @@ const {bar, baz} = (function () {
 })();
 
 export default function demo() {
-  return bar() + baz();
+  return [bar(), baz()];
 }

--- a/test/fixtures/not-passed-args.js
+++ b/test/fixtures/not-passed-args.js
@@ -1,7 +1,7 @@
 DEFINE_MACRO(FOO, (input1, input2) => {
-  return [String(input1), String(input2)];
+  return [input1, input2];
 });
 
 export default function demo() {
-  return FOO(123).join('.');
+  return FOO(123);
 }

--- a/test/fixtures/scoped.js
+++ b/test/fixtures/scoped.js
@@ -1,0 +1,12 @@
+function foo() {
+  return SAME_NAME();
+  DEFINE_MACRO(SAME_NAME, ()=>'foo');
+}
+function bar() {
+  return SAME_NAME();
+  DEFINE_MACRO(SAME_NAME, ()=>'bar');
+}
+
+export default function demo () {
+  return [foo(), bar()];
+}

--- a/test/fixtures/unique-local-names.js
+++ b/test/fixtures/unique-local-names.js
@@ -9,5 +9,5 @@ DEFINE_MACRO(FOO2, () => {
 
 export default function demo () {
   var foo = 'foo-main';
-  return [String(FOO1()), String(FOO2()), String(foo)].join('.');
+  return [FOO1(), FOO2(), foo];
 }

--- a/test/index.js
+++ b/test/index.js
@@ -64,5 +64,6 @@ describe('Babel Macros', function () {
   run("not-passed-args", [123, undefined]);
   run("define-after-using", ["before", "after"]);
   run("scoped", ["foo", "bar"]);
+  run("different-levels", ["same level used", "parent level used", "parent-parent level used", "child level cannot used"]);
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -58,9 +58,10 @@ describe('Babel Macros', function () {
   run("map-filter", [2, 3, 4, 5]);
   run("some", true);
   run("redefine", "baz");
-  run("hoisting", "barbaz");
-  run("functions", "ARROW.ANONYMOUS.NAMED");
-  run("unique-local-names", "foo1.undefined.foo-main");
-  run("not-passed-args", "123.undefined");
+  run("hoisting", ["bar", "baz"]);
+  run("functions", ["ARROW", "ANONYMOUS", "NAMED"]);
+  run("unique-local-names", ["foo1", undefined, "foo-main"]);
+  run("not-passed-args", [123, undefined]);
+  run("define-after-using", ['before', 'after']);
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,7 @@ describe('Babel Macros', function () {
   run("functions", ["ARROW", "ANONYMOUS", "NAMED"]);
   run("unique-local-names", ["foo1", undefined, "foo-main"]);
   run("not-passed-args", [123, undefined]);
-  run("define-after-using", ['before', 'after']);
+  run("define-after-using", ["before", "after"]);
+  run("scoped", ["foo", "bar"]);
 });
 


### PR DESCRIPTION
1.0.2 fix crash when missed some arguments
1.0.3 fix behavior of same-name macros in different scopes. before this change same-name macros are re-declared. now macros in different scopes - are different macros.

if this changes ok, please merge, and publish package

PS for my error 1.0.2 actually pushed to master
PPS I in process for new stuff and ideas)
Also inline arrow-function in macro arguments is comming soon