### PR TITLE
bug-fix & performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ fix combining more than 2 macros
 - **1.0.8** block using `this` and `arguments` in macros
 - **1.0.9** fix multiple `return` & `return` without value
 - **1.0.10** optimize performance of compile. x10 at tests 
+- **1.0.11** depedency for lodash no more needed 
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ fix combining more than 2 macros
 - **1.0.6** honest exception for infinite recursion in macros
 - **1.0.7** add checking types in runtime
 - **1.0.8** block using `this` and `arguments` in macros
+- **1.0.8** fix multiple `return` & `return` without value
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ fix combining more than 2 macros
 - **1.0.6** honest exception for infinite recursion in macros
 - **1.0.7** add checking types in runtime
 - **1.0.8** block using `this` and `arguments` in macros
-- **1.0.8** fix multiple `return` & `return` without value
+- **1.0.9** fix multiple `return` & `return` without value
+- **1.0.10** optimize performance of compile. x10 at tests 
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-macros",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Macros for JavaScript via a babel plugin.",
   "main": "lib/index.js",
   "scripts": {
@@ -40,6 +40,5 @@
     "should": "^6.0.3"
   },
   "dependencies": {
-    "lodash": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-macros",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Macros for JavaScript via a babel plugin.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-macros",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Macros for JavaScript via a babel plugin.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-import _ from 'lodash';
+import {cloneDeep} from './utils';
 
 const $registeredMacros = Symbol('registeredMacros');
 const $macroState = Symbol('macroState');
+const $processedByMacro = Symbol('processedByMacro');
 
 /**
  * # Babel Macros
@@ -85,7 +86,7 @@ export default function build (babel: Object): Object {
       }, scope);
     }
     return function (path, scope, state) {
-      const cloned = _.cloneDeep(node);
+      const cloned = cloneDeep(node);
       const uid = scope.generateUidIdentifier(camelCase(name));
       const labelUid = scope.generateUidIdentifier('_' + name.toUpperCase());
 
@@ -246,7 +247,7 @@ export default function build (babel: Object): Object {
       enter (path, state) {
         const node = path.node;
         if(state[$macroState].macrosDefined) {
-          if (node._processedByMacro) {
+          if (node[$processedByMacro]) {
             return;
           }
         }
@@ -273,7 +274,7 @@ export default function build (babel: Object): Object {
         }
 
         if(state[$macroState].macrosDefined) {
-          node._processedByMacro = true;
+          node[$processedByMacro] = true;
         }
       }
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,25 @@
+export function cloneDeep(node /*: Object*/) /*: Object*/ {
+  var newNode = Object.create(Object.getPrototypeOf(node)),
+    keys = Object.keys(node)
+      .concat(Object.getOwnPropertySymbols(node)),
+    length = keys.length,
+    key,
+    i
+    ;
+  for(i = 0; i < length; i++) {
+    key = keys[i];
+    if (key[0] === "_") {
+      continue;
+    }
+    var val = node[key];
+    if (val) {
+      if (val.type) {
+        val = cloneDeep(val);
+      } else if (Array.isArray(val)) {
+        val = val.map(cloneDeep);
+      }
+    }
+    newNode[key] = val;
+  }
+  return newNode;
+};

--- a/test/fixtures/multiple-return.js
+++ b/test/fixtures/multiple-return.js
@@ -1,0 +1,8 @@
+DEFINE_MACRO(ID, function() {
+  return 'foo';
+  return 'bar';
+});
+
+export default function demo () {
+  return ID();
+}

--- a/test/fixtures/no-return.js
+++ b/test/fixtures/no-return.js
@@ -1,0 +1,6 @@
+DEFINE_MACRO(ID, function() {
+});
+
+export default function demo () {
+  return typeof ID();
+}

--- a/test/fixtures/return-with-no-value.js
+++ b/test/fixtures/return-with-no-value.js
@@ -1,0 +1,7 @@
+DEFINE_MACRO(ID, function() {
+  return;
+});
+
+export default function demo () {
+  return typeof ID();
+}

--- a/test/index.js
+++ b/test/index.js
@@ -92,5 +92,8 @@ describe('Babel Macros', function () {
   run("wrong-function", new Error("unknown: Second argument to DEFINE_MACRO must be a FunctionExpression or ArrowFunctionExpression, at Line: 4 Column: 0"));
   run("this-in-macro", new Error("unknown: Can not use `this` in macro, at Line: 1 Column: 0"));
   run("arguments-in-macro", new Error("unknown: Can not use `arguments` in macro, at Line: 1 Column: 0"));
+  run("no-return", "undefined");
+  run("return-with-no-value", "undefined");
+  run("multiple-return", "foo");
 });
 


### PR DESCRIPTION
fixed bug for `return` in macro
* multiple return
* return without value
Also small refactoring. AST-nodes for multiple-return cases changes in traverse.
Changing AST out of traverse - bad idea, becaus NodePath lost his TraversalContext, and may crashed on some operations

Optimization:
change _.cloneDeep to cloneDeep based on babel-types.cloneDeep
This is more faster, before skipping big object in *private* props, like _paths
But without _paths - we can no longer changing AST out of traverse
But this problem fixed by previous commit)